### PR TITLE
procServ unix socket fallback

### DIFF
--- a/iocBoot/iocARAmp/runProcServ.sh
+++ b/iocBoot/iocARAmp/runProcServ.sh
@@ -6,9 +6,9 @@ set +u
 # Parse command-line options
 . ./parseCMDOpts.sh "$@"
 
-# Use defaults if not set
+UNIX_SOCKET=""
 if [ -z "${DEVICE_TELNET_PORT}" ]; then
-   DEVICE_TELNET_PORT="20000"
+    UNIX_SOCKET="true"
 fi
 
 if [ -z "${ARAMP_INSTANCE}" ]; then
@@ -18,4 +18,18 @@ fi
 set -u
 
 # Run run*.sh scripts with procServ
-/usr/local/bin/procServ -f -n ${ARAMP_INSTANCE} -i ^C^D ${DEVICE_TELNET_PORT} ./runARAmp.sh "$@"
+if [ "${UNIX_SOCKET}" ]; then
+    /usr/local/bin/procServ \
+        --foreground \
+        --name ${ARAMP_INSTANCE} \
+        --ignore ^C^D \
+        unix:./procserv.sock \
+            ./runARAmp.sh "$@"
+else
+    /usr/local/bin/procServ \
+        --foreground \
+        --name ${ARAMP_INSTANCE} \
+        --ignore ^C^D \
+        ${DEVICE_TELNET_PORT} \
+            ./runARAmp.sh "$@"
+fi

--- a/iocBoot/iocARAmp/runProcServ.sh
+++ b/iocBoot/iocARAmp/runProcServ.sh
@@ -20,6 +20,7 @@ set -u
 # Run run*.sh scripts with procServ
 if [ "${UNIX_SOCKET}" ]; then
     /usr/local/bin/procServ \
+        --logfile - \
         --foreground \
         --name ${ARAMP_INSTANCE} \
         --ignore ^C^D \
@@ -27,6 +28,7 @@ if [ "${UNIX_SOCKET}" ]; then
             ./runARAmp.sh "$@"
 else
     /usr/local/bin/procServ \
+        --logfile - \
         --foreground \
         --name ${ARAMP_INSTANCE} \
         --ignore ^C^D \


### PR DESCRIPTION
Instead of using the default port value, the runProcServ.sh script will use UNIX sockets.